### PR TITLE
Added Notion to commercial apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ Made with Electron.
 - [MusicPlus](https://musicplus.io) - Free music app for macOS and Windows.
 - [Mingo](https://mingo.io) - MongoDB GUI.
 - [Moon Modeler](https://datensen.com) - Schema design tool for MongoDB, Mongoose, and MariaDB.
+- [Notion](https://notion.so) - The all-in-one workspace for your notes, tasks, wikis, and databases.
 
 ### Samples
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

https://notion.so is the app I'm submitting. I did not create this, but it's a pretty widely used note taking application that people keep on hyping on twitter etc. It's listed in the official [Electron Apps](https://electronjs.org/apps/notion) page and it's semi-public information that it's built with Electron but I don't have any better sources to link to though.